### PR TITLE
Bump fmtlib to 11.0.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -153,7 +153,7 @@ endif()
 if(NOT TARGET fmt::fmt)
     if(KOMPUTE_OPT_USE_BUILT_IN_FMT)
         FetchContent_Declare(fmt GIT_REPOSITORY https://github.com/fmtlib/fmt.git
-            GIT_TAG 10.0.0) # Source: https://github.com/fmtlib/fmt/releases
+            GIT_TAG 11.0.0) # Source: https://github.com/fmtlib/fmt/releases
         FetchContent_MakeAvailable(fmt)
     else()
         find_package(fmt REQUIRED)


### PR DESCRIPTION
Bump fmtlib to 11.0.0 to avoid errors with the latest compilers.